### PR TITLE
Disables status checks

### DIFF
--- a/otterdog/eclipse-cbi.jsonnet
+++ b/otterdog/eclipse-cbi.jsonnet
@@ -3,7 +3,7 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 local newBranchProtectionRule(branchName) = orgs.newBranchProtectionRule(branchName) {
   required_approving_review_count: null,
   requires_pull_request: false,
-  required_status_checks: false,
+  requires_status_checks: false,
 };
 
 orgs.newOrg('eclipse-cbi') {


### PR DESCRIPTION
This PR disables status checks as they are enforced even if no pull requests are mandatory.
As the eca status checks will only be done for pull requests, this leads to a situation where people can not push to the main branch anymore without PR.

Disabling for now until we have a better solution.